### PR TITLE
Implement space import REST endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 /.settings
 
 .openapi-generator*
+jacoco.exec

--- a/index.adoc
+++ b/index.adoc
@@ -313,6 +313,129 @@ endif::internal-generation[]
 === Backup
 
 
+[.doImportByFileUpload]
+==== doImportByFileUpload
+    
+`PUT /backup/import`
+
+Import based on an export file upload
+
+===== Description 
+
+Initiates an asynchronous import if enabled by server, synchronous otherwise
+
+
+// markup not found, no include::{specDir}backup/import/PUT/spec.adoc[opts=optional]
+
+
+
+===== Parameters
+
+
+
+===== Form Parameter
+
+[cols="2,3,1,1,1"]
+|===         
+|Name| Description| Required| Default| Pattern
+
+| contentType 
+|  <<string>> 
+| - 
+| null 
+|  
+
+| formField 
+|  <<boolean>> 
+| - 
+| null 
+|  
+
+| name 
+|  <<string>> 
+| - 
+| null 
+|  
+
+| value 
+|  <<string>> 
+| - 
+| null 
+|  
+
+| size 
+|  <<long>> 
+| - 
+| null 
+|  
+
+| inputStream 
+|  <<object>> 
+| - 
+| null 
+|  
+
+|===         
+
+
+
+
+===== Return Type
+
+
+
+-
+
+===== Content Type
+
+* application/json
+
+===== Responses
+
+.http response codes
+[cols="2,3,1"]
+|===         
+| Code | Message | Datatype 
+
+
+| 201
+| Synchronous import
+|  <<>>
+
+
+| 202
+| Asynchronous import, the queue URL will be returned in the location header
+|  <<>>
+
+
+| 0
+| 
+|  <<ErrorCollection>>
+
+|===         
+
+===== Samples
+
+
+// markup not found, no include::{snippetDir}backup/import/PUT/http-request.adoc[opts=optional]
+
+
+// markup not found, no include::{snippetDir}backup/import/PUT/http-response.adoc[opts=optional]
+
+
+
+// file not found, no * wiremock data link :backup/import/PUT/PUT.json[]
+
+
+ifdef::internal-generation[]
+===== Implementation
+
+// markup not found, no include::{specDir}backup/import/PUT/implementation.adoc[opts=optional]
+
+
+endif::internal-generation[]
+
+
 [.getExport]
 ==== getExport
     
@@ -406,8 +529,8 @@ ifdef::internal-generation[]
 endif::internal-generation[]
 
 
-[.getExportBySpaceKey]
-==== getExportBySpaceKey
+[.getExportByKey]
+==== getExportByKey
     
 `GET /backup/export/{key}`
 
@@ -3268,6 +3391,55 @@ endif::internal-generation[]
 | errorMessages 
 |  
 | List  of <<string>> 
+| 
+|  
+
+|===
+
+
+[#FilePart]
+=== _FilePart_ 
+
+
+
+[.fields-FilePart]
+[cols="2,1,2,4,1"]
+|===         
+| Field Name| Required| Type| Description| Format
+
+| contentType 
+|  
+| String  
+| 
+|  
+
+| formField 
+|  
+| Boolean  
+| 
+|  
+
+| name 
+|  
+| String  
+| 
+|  
+
+| value 
+|  
+| String  
+| 
+|  
+
+| size 
+|  
+| Long  
+| 
+| int64 
+
+| inputStream 
+|  
+| Object  
 | 
 |  
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>de.aservo</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>0.0.10</version>
+        <version>0.0.11</version>
     </parent>
 
     <artifactId>confapi-confluence-plugin</artifactId>
@@ -66,7 +66,7 @@
         <log4j.version>2.8.2</log4j.version>
         <openapi-generator-maven-plugin.version>4.3.0</openapi-generator-maven-plugin.version>
         <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
-        <powermock-api-easymock.version>2.0.5</powermock-api-easymock.version>
+        <powermock-api-easymock.version>2.0.7</powermock-api-easymock.version>
         <slf4j.version>1.7.30</slf4j.version>
     </properties>
 
@@ -291,6 +291,14 @@
             <artifactId>slf4j-simple</artifactId>
             <version>${slf4j.version}</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+            <version>0.8.5</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/de/aservo/confapi/confluence/rest/BackupResourceImpl.java
+++ b/src/main/java/de/aservo/confapi/confluence/rest/BackupResourceImpl.java
@@ -1,5 +1,6 @@
 package de.aservo.confapi.confluence.rest;
 
+import com.atlassian.plugins.rest.common.multipart.FilePart;
 import com.sun.jersey.spi.container.ResourceFilters;
 import de.aservo.confapi.commons.constants.ConfAPI;
 import de.aservo.confapi.confluence.filter.SysAdminOnlyResourceFilter;
@@ -7,12 +8,14 @@ import de.aservo.confapi.confluence.model.BackupBean;
 import de.aservo.confapi.confluence.model.BackupQueueBean;
 import de.aservo.confapi.confluence.rest.api.BackupResource;
 import de.aservo.confapi.confluence.service.api.BackupService;
+import de.aservo.confapi.confluence.util.FilePartUtil;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
+import java.io.File;
 
 import static de.aservo.confapi.confluence.util.HttpUtil.isLongRunningTaskSupported;
 import static javax.ws.rs.core.Response.Status.*;
@@ -58,6 +61,21 @@ public class BackupResourceImpl implements BackupResource {
         return getExport(backupBean);
     }
 
+    public Response doImportByFileUpload(
+            @Nonnull final FilePart filePart) {
+
+        final File file = FilePartUtil.createFile(filePart);
+
+        if (isLongRunningTaskSupported()) {
+            return Response.status(ACCEPTED)
+                    .location(backupService.doImportAsynchronously(file))
+                    .build();
+        }
+
+        backupService.doImportSynchronously(file);
+        return Response.status(CREATED).build();
+    }
+
     @Override
     public Response getQueue(
             @Nonnull final String uuid) {
@@ -70,15 +88,15 @@ public class BackupResourceImpl implements BackupResource {
 
         // It's not possible to create a ResponseBuilder without a status,
         // so take "ok", which is returned if task has not completed yet
-        Response.ResponseBuilder responseBuilder = Response.ok().entity(backupQueueBean);
+        final Response.ResponseBuilder responseBuilder = Response.ok().entity(backupQueueBean);
 
         if (backupQueueBean.getPercentageComplete() == 100) {
             // override responseBuilder status when task is completed
-            responseBuilder = responseBuilder.status(CREATED);
+            responseBuilder.status(CREATED);
 
             if (backupQueueBean.getEntityUri() != null) {
                 // set location header if entity URI is set
-                responseBuilder = responseBuilder.location(backupQueueBean.getEntityUri());
+                responseBuilder.location(backupQueueBean.getEntityUri());
             }
         }
 

--- a/src/main/java/de/aservo/confapi/confluence/rest/BackupResourceImpl.java
+++ b/src/main/java/de/aservo/confapi/confluence/rest/BackupResourceImpl.java
@@ -47,7 +47,7 @@ public class BackupResourceImpl implements BackupResource {
     }
 
     @Override
-    public Response getExportBySpaceKey(
+    public Response getExportByKey(
             @Nonnull final String key) {
 
         final BackupBean backupBean = new BackupBean();

--- a/src/main/java/de/aservo/confapi/confluence/rest/api/BackupResource.java
+++ b/src/main/java/de/aservo/confapi/confluence/rest/api/BackupResource.java
@@ -50,7 +50,7 @@ public interface BackupResource {
                     @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
             }
     )
-    Response getExportBySpaceKey(
+    Response getExportByKey(
             @Nonnull @PathParam("key") String key);
 
     @GET

--- a/src/main/java/de/aservo/confapi/confluence/rest/api/BackupResource.java
+++ b/src/main/java/de/aservo/confapi/confluence/rest/api/BackupResource.java
@@ -1,5 +1,7 @@
 package de.aservo.confapi.confluence.rest.api;
 
+import com.atlassian.plugins.rest.common.multipart.FilePart;
+import com.atlassian.plugins.rest.common.multipart.MultipartFormParam;
 import de.aservo.confapi.commons.constants.ConfAPI;
 import de.aservo.confapi.commons.model.ErrorCollection;
 import de.aservo.confapi.confluence.model.BackupBean;
@@ -12,6 +14,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import javax.annotation.Nonnull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -31,7 +34,7 @@ public interface BackupResource {
             responses = {
                     @ApiResponse(responseCode = "201", description = "Synchronous export, the download URL will be returned in the location header"),
                     @ApiResponse(responseCode = "202", description = "Asynchronous export, the queue URL will be returned in the location header"),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
+                    @ApiResponse(content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
             }
     )
     Response getExport(
@@ -47,11 +50,28 @@ public interface BackupResource {
             responses = {
                     @ApiResponse(responseCode = "201", description = "Synchronous export, the download URL will be returned in the location header"),
                     @ApiResponse(responseCode = "202", description = "Asynchronous export, the queue URL will be returned in the location header"),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
+                    @ApiResponse(content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
             }
     )
     Response getExportByKey(
             @Nonnull @PathParam("key") String key);
+
+    @PUT
+    @Path(ConfAPI.BACKUP_IMPORT)
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            tags = { ConfAPI.BACKUP },
+            summary = "Import based on an export file upload",
+            description = "Initiates an asynchronous import if enabled by server, synchronous otherwise",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "Synchronous import"),
+                    @ApiResponse(responseCode = "202", description = "Asynchronous import, the queue URL will be returned in the location header"),
+                    @ApiResponse(content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
+            }
+    )
+    Response doImportByFileUpload(
+            @Nonnull @MultipartFormParam("file") final FilePart filePart);
 
     @GET
     @Path(ConfAPI.BACKUP_QUEUE + "/{uuid}")
@@ -70,7 +90,7 @@ public interface BackupResource {
                             description = "Task completed, return download URL in the location header (export only)"
                     ),
                     @ApiResponse(responseCode = "404", description = "No task found for the given UUID"),
-                    @ApiResponse(responseCode = "default", content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
+                    @ApiResponse(content = @Content(schema = @Schema(implementation = ErrorCollection.class)))
             }
     )
     Response getQueue(

--- a/src/main/java/de/aservo/confapi/confluence/service/api/BackupService.java
+++ b/src/main/java/de/aservo/confapi/confluence/service/api/BackupService.java
@@ -3,6 +3,7 @@ package de.aservo.confapi.confluence.service.api;
 import de.aservo.confapi.confluence.model.BackupBean;
 import de.aservo.confapi.confluence.model.BackupQueueBean;
 
+import java.io.File;
 import java.net.URI;
 
 public interface BackupService {
@@ -12,6 +13,12 @@ public interface BackupService {
 
     URI getExportAsynchronously(
             BackupBean backupBean);
+
+    void doImportSynchronously(
+            File filePart);
+
+    URI doImportAsynchronously(
+            File filePart);
 
     BackupQueueBean getQueue(
             String uuid);

--- a/src/main/java/de/aservo/confapi/confluence/util/FilePartUtil.java
+++ b/src/main/java/de/aservo/confapi/confluence/util/FilePartUtil.java
@@ -1,0 +1,74 @@
+package de.aservo.confapi.confluence.util;
+
+import com.atlassian.plugins.rest.common.multipart.FilePart;
+import com.opensymphony.webwork.config.Configuration;
+import de.aservo.confapi.commons.exception.InternalServerErrorException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import static com.atlassian.confluence.setup.ConfluenceBootstrapConstants.TEMP_DIR_PROP;
+
+public class FilePartUtil {
+
+    private static final Logger log = LoggerFactory.getLogger(FilePartUtil.class);
+
+    public static File createFile(
+            @Nonnull final FilePart filePart) {
+
+        final File uploadDirectory = getUploadDirectory();
+
+        if (!uploadDirectory.exists() && !uploadDirectory.mkdirs()) {
+            throw new InternalServerErrorException(String.format(
+                    "Failed to create directory %s", uploadDirectory.getAbsolutePath()));
+        } else if (uploadDirectory.isFile()) {
+            throw new InternalServerErrorException(String.format(
+                    "Failed to create directory %s as a file of that name already exists", uploadDirectory.getAbsolutePath()));
+        }
+
+        log.info("Uploaded export file {}", filePart.getName());
+        final File writtenFile;
+
+        try {
+            writtenFile = writeToFile(filePart.getInputStream(), uploadDirectory, filePart.getName());
+        } catch (IOException e) {
+            throw new InternalServerErrorException("Failed to write file to upload directory");
+        }
+
+        log.info("Uploaded export file written to {}", writtenFile);
+        return writtenFile;
+    }
+
+    public static File getUploadDirectory() {
+        final String uploadDirectoryPath = Configuration.getString(TEMP_DIR_PROP);
+        return new File(uploadDirectoryPath);
+    }
+
+    static File writeToFile(
+            @Nonnull final InputStream uploadedInputStream,
+            @Nonnull final File directory,
+            @Nonnull final String fileName) throws IOException {
+
+        int read = 0;
+        byte[] bytes = new byte[1024];
+
+        final File file = new File(directory, fileName);
+        try (OutputStream out = new FileOutputStream(file)) {
+            while ((read = uploadedInputStream.read(bytes)) != -1) {
+                out.write(bytes, 0, read);
+            }
+            out.flush();
+        }
+
+        return file;
+    }
+
+    private FilePartUtil() {}
+
+}

--- a/src/test/java/de/aservo/confapi/confluence/rest/BackupResourceTest.java
+++ b/src/test/java/de/aservo/confapi/confluence/rest/BackupResourceTest.java
@@ -50,7 +50,7 @@ public class BackupResourceTest {
 
         doReturn(BACKUP_QUEUE_URI).when(backupService).getExportAsynchronously(any(BackupBean.class));
 
-        final Response response = backupResource.getExportBySpaceKey("space");
+        final Response response = backupResource.getExportByKey("space");
         assertEquals(ACCEPTED.getStatusCode(), response.getStatus());
         assertNotNull(response.getMetadata().getFirst(RESPONSE_METADATA_LOCATION));
     }
@@ -63,7 +63,7 @@ public class BackupResourceTest {
 
         doReturn(BACKUP_QUEUE_URI).when(backupService).getExportSynchronously(any(BackupBean.class));
 
-        final Response response = backupResource.getExportBySpaceKey("space");
+        final Response response = backupResource.getExportByKey("space");
         assertEquals(CREATED.getStatusCode(), response.getStatus());
         assertNotNull(response.getMetadata().getFirst(RESPONSE_METADATA_LOCATION));
     }

--- a/src/test/java/de/aservo/confapi/confluence/rest/BackupResourceTest.java
+++ b/src/test/java/de/aservo/confapi/confluence/rest/BackupResourceTest.java
@@ -1,8 +1,10 @@
 package de.aservo.confapi.confluence.rest;
 
+import com.atlassian.plugins.rest.common.multipart.FilePart;
 import de.aservo.confapi.confluence.model.BackupBean;
 import de.aservo.confapi.confluence.model.BackupQueueBean;
 import de.aservo.confapi.confluence.service.api.BackupService;
+import de.aservo.confapi.confluence.util.FilePartUtil;
 import de.aservo.confapi.confluence.util.HttpUtil;
 import org.junit.Before;
 import org.junit.Test;
@@ -14,6 +16,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import javax.ws.rs.core.Response;
+import java.io.File;
 import java.net.URI;
 
 import static javax.ws.rs.core.Response.Status.*;
@@ -21,9 +24,10 @@ import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(HttpUtil.class)
+@PrepareForTest({HttpUtil.class, FilePartUtil.class})
 public class BackupResourceTest {
 
     private static final URI BACKUP_ZIP_URI = URI.create("http://localhost:1990/confluence/space-export.zip");
@@ -66,6 +70,43 @@ public class BackupResourceTest {
         final Response response = backupResource.getExportByKey("space");
         assertEquals(CREATED.getStatusCode(), response.getStatus());
         assertNotNull(response.getMetadata().getFirst(RESPONSE_METADATA_LOCATION));
+    }
+
+    @Test
+    public void testDoImportByUploadAsynchronously() {
+        PowerMock.mockStatic(HttpUtil.class);
+        expect(HttpUtil.isLongRunningTaskSupported()).andReturn(Boolean.TRUE);
+        PowerMock.replay(HttpUtil.class);
+
+        final FilePart filePart = mock(FilePart.class);
+        final File file = mock(File.class);
+
+        PowerMock.mockStatic(FilePartUtil.class);
+        expect(FilePartUtil.createFile(filePart)).andReturn(file);
+        PowerMock.replay(FilePartUtil.class);
+
+        doReturn(BACKUP_QUEUE_URI).when(backupService).doImportAsynchronously(file);
+
+        final Response response = backupResource.doImportByFileUpload(filePart);
+        assertEquals(ACCEPTED.getStatusCode(), response.getStatus());
+        assertNotNull(response.getMetadata().getFirst(RESPONSE_METADATA_LOCATION));
+    }
+
+    @Test
+    public void testDoImportByUploadSynchronously() {
+        PowerMock.mockStatic(HttpUtil.class);
+        expect(HttpUtil.isLongRunningTaskSupported()).andReturn(Boolean.FALSE);
+        PowerMock.replay(HttpUtil.class);
+
+        final FilePart filePart = mock(FilePart.class);
+        final File file = mock(File.class);
+
+        PowerMock.mockStatic(FilePartUtil.class);
+        expect(FilePartUtil.createFile(filePart)).andReturn(file);
+        PowerMock.replay(FilePartUtil.class);
+
+        final Response response = backupResource.doImportByFileUpload(filePart);
+        assertEquals(CREATED.getStatusCode(), response.getStatus());
     }
 
     @Test

--- a/src/test/java/de/aservo/confapi/confluence/util/FilePartUtilTest.java
+++ b/src/test/java/de/aservo/confapi/confluence/util/FilePartUtilTest.java
@@ -1,0 +1,103 @@
+package de.aservo.confapi.confluence.util;
+
+import com.atlassian.plugins.rest.common.multipart.FilePart;
+import com.opensymphony.webwork.config.Configuration;
+import de.aservo.confapi.commons.exception.InternalServerErrorException;
+import org.easymock.EasyMock;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+
+import static com.atlassian.confluence.setup.ConfluenceBootstrapConstants.TEMP_DIR_PROP;
+import static org.easymock.EasyMock.expect;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.*;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Configuration.class, FilePartUtil.class})
+public class FilePartUtilTest {
+
+    public static final String EXPORT_FILE_NAME = "confluence-export.zip";
+    public static final String DOWNLOAD_PATH = "/path/to/download";
+
+    @Test
+    public void testCreateFile() throws IOException, NoSuchMethodException {
+        final FilePart filePart = mock(FilePart.class);
+        doReturn(EXPORT_FILE_NAME).when(filePart).getName();
+        doReturn(mock(InputStream.class)).when(filePart).getInputStream();
+
+        final File uploadDirectory = spy(new File(DOWNLOAD_PATH));
+        doReturn(true).when(uploadDirectory).exists();
+        doReturn(true).when(uploadDirectory).mkdirs();
+
+        final File writtenFile = new File(uploadDirectory, EXPORT_FILE_NAME);
+
+        final Method getUploadDirectoryMethod = FilePartUtil.class.getDeclaredMethod("getUploadDirectory");
+        final Method writeToFileMethod = FilePartUtil.class.getDeclaredMethod("writeToFile", InputStream.class, File.class, String.class);
+
+        PowerMock.mockStatic(FilePartUtil.class, getUploadDirectoryMethod, writeToFileMethod);
+        expect(FilePartUtil.getUploadDirectory()).andReturn(uploadDirectory).anyTimes();
+        expect(FilePartUtil.writeToFile(EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyString())).andReturn(writtenFile).anyTimes();
+        PowerMock.replay(FilePartUtil.class);
+
+        assertNotNull(FilePartUtil.createFile(filePart));
+    }
+
+    @Test(expected = InternalServerErrorException.class)
+    public void testCreateFileCannotCreateUploadDirectory() throws IOException, NoSuchMethodException {
+        final FilePart filePart = mock(FilePart.class);
+        doReturn(EXPORT_FILE_NAME).when(filePart).getName();
+        doReturn(mock(InputStream.class)).when(filePart).getInputStream();
+
+        final File uploadDirectory = spy(new File(DOWNLOAD_PATH));
+        doReturn(false).when(uploadDirectory).exists();
+        doReturn(false).when(uploadDirectory).mkdirs();
+
+        final Method getUploadDirectoryMethod = FilePartUtil.class.getDeclaredMethod("getUploadDirectory");
+
+        PowerMock.mockStatic(FilePartUtil.class, getUploadDirectoryMethod);
+        expect(FilePartUtil.getUploadDirectory()).andReturn(uploadDirectory).anyTimes();
+        PowerMock.replay(FilePartUtil.class);
+
+        FilePartUtil.createFile(filePart);
+    }
+
+    @Test(expected = InternalServerErrorException.class)
+    public void testCreateFileUploadPathIsFile() throws IOException, NoSuchMethodException {
+        final FilePart filePart = mock(FilePart.class);
+        doReturn(EXPORT_FILE_NAME).when(filePart).getName();
+        doReturn(mock(InputStream.class)).when(filePart).getInputStream();
+
+        final File uploadDirectory = spy(new File(DOWNLOAD_PATH));
+        doReturn(true).when(uploadDirectory).exists();
+        doReturn(true).when(uploadDirectory).isFile();
+
+        final Method getUploadDirectoryMethod = FilePartUtil.class.getDeclaredMethod("getUploadDirectory");
+
+        PowerMock.mockStatic(FilePartUtil.class, getUploadDirectoryMethod);
+        expect(FilePartUtil.getUploadDirectory()).andReturn(uploadDirectory).anyTimes();
+        PowerMock.replay(FilePartUtil.class);
+
+        FilePartUtil.createFile(filePart);
+    }
+
+    @Test
+    public void testGetUploadDirectory() {
+        PowerMock.mockStatic(Configuration.class);
+        expect(Configuration.getString(TEMP_DIR_PROP)).andReturn(DOWNLOAD_PATH).anyTimes();
+        PowerMock.replay(Configuration.class);
+
+        final File uploadDirectory = FilePartUtil.getUploadDirectory();
+        assertNotNull(uploadDirectory);
+        assertEquals(DOWNLOAD_PATH, uploadDirectory.getAbsolutePath());
+    }
+
+}


### PR DESCRIPTION
This is the follow-up PR to #11 which implements the backup import REST endpoint.

@lehmannk 

Ich würde ihn jetzt gerne mergen, es gibt aber ein Problem: Viele der Helfer-Methoden sind als statische Utils implementiert, die ich mit Powermock testen musste. Das hat auch geklappt, die Tests laufen, aber für die Tests von `FilePartUtil.java`  bekommt Jacoco die Coverage Messung nicht hin. Das Problem ist `@PrepareForTest({Configuration.class, FilePartUtil.class})`: Hier bereite ich quasi die Util-Klasse zum Mocken vor, in der ich später auch ungemockten Code testen möchte (also wie ein Spy). Wenn man die Klasse, die man testen will, in diese Annotation aufnimmt, gibt's in Maven folgende Meldung und die Coverage wird nicht erfasst:

```
[INFO] --- jacoco-maven-plugin:0.8.5:report (post-test) @ confapi-confluence-plugin ---
[INFO] Loading execution data file /home/patrick/dev/aservo/confapi/confluence/target/jacoco.exec
[INFO] Analyzed bundle 'ConfAPI for Confluence' with 70 classes
[WARNING] Classes in bundle 'ConfAPI for Confluence' do no match with execution data. For report generation the same class files must be used as at runtime.
[WARNING] Execution data for class de/aservo/confapi/confluence/util/FilePartUtil does not match.
```

Ich habe die Dinge ausprobiert, die dazu auf Stackoverflow und co. empfohlen wurden, aber leider ohne Erfolg.

Daher würde ich das jetzt gerne so machen: Die Coverage sollte um 80% liegen und wichtiger, die wichtigsten Teile von `FilePartUtil` sind getestet. Mit deinem Einverständnis und nach deiner Review würde ich den PR also gerne mergen, auch wenn der automatische Check nicht erfolgreich ist. Und in näherer Zukunft würde ich Powermock gerne wieder rausschmeißen und stattdessen auf Junit 5.x und Mockito 3.x umstellen.