### PR TITLE
ApplicationLinks Endpoint Update to Latest ConfAPI-Commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.atlassian.applinks</groupId>
+            <artifactId>applinks-plugin</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.atlassian.confluence</groupId>
             <artifactId>confluence-rest-api</artifactId>
             <scope>provided</scope>


### PR DESCRIPTION
This commit updates the application links service to fully represent the commons
api v 0.0.18. This specifically includes the deployment of the `status` parameter
as well as the interpretation of the `ignore-setup-errors` request arg.