### PR TITLE
Improve backup error handling

### DIFF
--- a/src/main/java/de/aservo/confapi/confluence/service/BackupServiceImpl.java
+++ b/src/main/java/de/aservo/confapi/confluence/service/BackupServiceImpl.java
@@ -24,6 +24,7 @@ import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
 import com.atlassian.spring.container.ContainerManager;
 import de.aservo.confapi.commons.exception.BadRequestException;
 import de.aservo.confapi.commons.exception.InternalServerErrorException;
+import de.aservo.confapi.commons.exception.NotFoundException;
 import de.aservo.confapi.confluence.model.BackupBean;
 import de.aservo.confapi.confluence.model.BackupQueueBean;
 import de.aservo.confapi.confluence.service.api.BackupService;
@@ -181,18 +182,15 @@ public class BackupServiceImpl implements BackupService {
             @Nullable final String spaceKey) {
 
         log.info("Trying to find space with key '{}'", spaceKey);
+
         if (StringUtils.isBlank(spaceKey)) {
-            final String message = "No space key given for export";
-            log.error(message);
-            throw new BadRequestException(message);
+            throw new BadRequestException("No space key given for export");
         }
 
         final Optional<Space> optionalSpace = spaceService.find().withKeys(spaceKey).fetch();
 
         if (!optionalSpace.isPresent()) {
-            final String message = String.format("Space with key %s does not exist", spaceKey);
-            log.error(message);
-            throw new BadRequestException(message);
+            throw new NotFoundException(String.format("Space with key '%s' does not exist", spaceKey));
         }
 
         return optionalSpace.get();

--- a/src/test/java/de/aservo/confapi/confluence/service/BackupServiceTest.java
+++ b/src/test/java/de/aservo/confapi/confluence/service/BackupServiceTest.java
@@ -19,6 +19,7 @@ import com.atlassian.core.task.longrunning.LongRunningTask;
 import com.atlassian.event.api.EventPublisher;
 import de.aservo.confapi.commons.exception.BadRequestException;
 import de.aservo.confapi.commons.exception.InternalServerErrorException;
+import de.aservo.confapi.commons.exception.NotFoundException;
 import de.aservo.confapi.confluence.model.BackupBean;
 import de.aservo.confapi.confluence.model.BackupQueueBean;
 import de.aservo.confapi.confluence.util.HttpUtil;
@@ -331,7 +332,7 @@ public class BackupServiceTest {
         backupService.getSpace("");
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test(expected = NotFoundException.class)
     public void testGetSpaceNotExists() {
         final SpaceService.SpaceFinder spaceFinder = mock(SpaceService.SpaceFinder.class);
         doReturn(spaceFinder).when(spaceFinder).withKeys(SPACE_KEY);


### PR DESCRIPTION
**Commit 1**

Use NotFoundException when export space is not found

**Commit 2**

Implement file validation and space check for imports

The backup/import REST endpoint sends now BadRequestExceptions for the following 
cases:

* Given (zip) file is not an export file
  * It does not contain entities.xml
  * It does not contain exportDescriptor.properties
* Export file is not a space export (maybe system export)
* Export file does not contain space key
* Export file's space key already exists

The import task has a very bad error handling, this is why we should restrict 
the imports to space imports (for now) so we can handle the most important case 
(space key already exists) by ourselves.