### PR TITLE
Change from PUT to POST for space imports

### DIFF
--- a/index.adoc
+++ b/index.adoc
@@ -316,7 +316,7 @@ endif::internal-generation[]
 [.doImportByFileUpload]
 ==== doImportByFileUpload
     
-`PUT /backup/import`
+`POST /backup/import`
 
 Import based on an export file upload
 
@@ -325,7 +325,7 @@ Import based on an export file upload
 Initiates an asynchronous import if enabled by server, synchronous otherwise
 
 
-// markup not found, no include::{specDir}backup/import/PUT/spec.adoc[opts=optional]
+// markup not found, no include::{specDir}backup/import/POST/spec.adoc[opts=optional]
 
 
 
@@ -339,14 +339,14 @@ Initiates an asynchronous import if enabled by server, synchronous otherwise
 |===         
 |Name| Description| Required| Default| Pattern
 
-| contentType 
-|  <<string>> 
+| formField 
+|  <<boolean>> 
 | - 
 | null 
 |  
 
-| formField 
-|  <<boolean>> 
+| contentType 
+|  <<string>> 
 | - 
 | null 
 |  
@@ -417,20 +417,20 @@ Initiates an asynchronous import if enabled by server, synchronous otherwise
 ===== Samples
 
 
-// markup not found, no include::{snippetDir}backup/import/PUT/http-request.adoc[opts=optional]
+// markup not found, no include::{snippetDir}backup/import/POST/http-request.adoc[opts=optional]
 
 
-// markup not found, no include::{snippetDir}backup/import/PUT/http-response.adoc[opts=optional]
+// markup not found, no include::{snippetDir}backup/import/POST/http-response.adoc[opts=optional]
 
 
 
-// file not found, no * wiremock data link :backup/import/PUT/PUT.json[]
+// file not found, no * wiremock data link :backup/import/POST/POST.json[]
 
 
 ifdef::internal-generation[]
 ===== Implementation
 
-// markup not found, no include::{specDir}backup/import/PUT/implementation.adoc[opts=optional]
+// markup not found, no include::{specDir}backup/import/POST/implementation.adoc[opts=optional]
 
 
 endif::internal-generation[]
@@ -2570,6 +2570,36 @@ endif::internal-generation[]
 | 
 |  
 
+| server 
+|  
+| DirectoryLdapServer  
+| 
+|  
+
+| permissions 
+|  
+| DirectoryLdapPermissions  
+| 
+|  
+
+| advanced 
+|  
+| DirectoryInternalAdvanced  
+| 
+|  
+
+| credentialPolicy 
+|  
+| DirectoryInternalCredentialPolicy  
+| 
+|  
+
+| schema 
+|  
+| DirectoryLdapSchema  
+| 
+|  
+
 |===
 
 
@@ -3371,15 +3401,15 @@ endif::internal-generation[]
 |===         
 | Field Name| Required| Type| Description| Format
 
-| contentType 
-|  
-| String  
-| 
-|  
-
 | formField 
 |  
 | Boolean  
+| 
+|  
+
+| contentType 
+|  
+| String  
 | 
 |  
 

--- a/src/main/java/de/aservo/confapi/confluence/rest/api/BackupResource.java
+++ b/src/main/java/de/aservo/confapi/confluence/rest/api/BackupResource.java
@@ -1,5 +1,6 @@
 package de.aservo.confapi.confluence.rest.api;
 
+import com.atlassian.annotations.security.XsrfProtectionExcluded;
 import com.atlassian.plugins.rest.common.multipart.FilePart;
 import com.atlassian.plugins.rest.common.multipart.MultipartFormParam;
 import de.aservo.confapi.commons.constants.ConfAPI;
@@ -14,7 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import javax.annotation.Nonnull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -56,7 +57,8 @@ public interface BackupResource {
     Response getExportByKey(
             @Nonnull @PathParam("key") String key);
 
-    @PUT
+    @POST
+    @XsrfProtectionExcluded
     @Path(ConfAPI.BACKUP_IMPORT)
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
Bin heute zufällig darüber gestolpert, wie ich diese Xsrf Checks vermeiden kann, wenn ich beim Upload POST statt PUT verwende. Daher nochmal fix vor Release die Korrektur für einen 'korrekteren' Endpoint.