### PR TITLE
Use proper type for backup UUID's

### DIFF
--- a/index.adoc
+++ b/index.adoc
@@ -703,6 +703,12 @@ Initiates an asynchronous import if enabled by server, synchronous otherwise
 |===         
 |Name| Description| Required| Default| Pattern
 
+| contentType 
+|  <<string>> 
+| - 
+| null 
+|  
+
 | name 
 |  <<string>> 
 | - 
@@ -723,12 +729,6 @@ Initiates an asynchronous import if enabled by server, synchronous otherwise
 
 | inputStream 
 |  <<object>> 
-| - 
-| null 
-|  
-
-| contentType 
-|  <<string>> 
 | - 
 | null 
 |  
@@ -3836,6 +3836,36 @@ endif::internal-generation[]
 | 
 |  
 
+| server 
+|  
+| DirectoryLdapServer  
+| 
+|  
+
+| permissions 
+|  
+| DirectoryLdapPermissions  
+| 
+|  
+
+| advanced 
+|  
+| DirectoryInternalAdvanced  
+| 
+|  
+
+| credentialPolicy 
+|  
+| DirectoryInternalCredentialPolicy  
+| 
+|  
+
+| schema 
+|  
+| DirectoryLdapSchema  
+| 
+|  
+
 |===
 
 
@@ -3854,12 +3884,6 @@ endif::internal-generation[]
 | UUID  
 | 
 | uuid 
-
-| serverId 
-|  
-| String  
-| 
-|  
 
 | name 
 | X 
@@ -4643,6 +4667,12 @@ endif::internal-generation[]
 |===         
 | Field Name| Required| Type| Description| Format
 
+| contentType 
+|  
+| String  
+| 
+|  
+
 | name 
 |  
 | String  
@@ -4664,12 +4694,6 @@ endif::internal-generation[]
 | inputStream 
 |  
 | Object  
-| 
-|  
-
-| contentType 
-|  
-| String  
 | 
 |  
 

--- a/src/main/java/de/aservo/confapi/confluence/rest/BackupResourceImpl.java
+++ b/src/main/java/de/aservo/confapi/confluence/rest/BackupResourceImpl.java
@@ -16,6 +16,7 @@ import javax.inject.Inject;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 import java.io.File;
+import java.util.UUID;
 
 import static de.aservo.confapi.confluence.util.HttpUtil.isLongRunningTaskSupported;
 import static javax.ws.rs.core.Response.Status.*;
@@ -78,7 +79,7 @@ public class BackupResourceImpl implements BackupResource {
 
     @Override
     public Response getQueue(
-            @Nonnull final String uuid) {
+            @Nonnull final UUID uuid) {
 
         final BackupQueueBean backupQueueBean = backupService.getQueue(uuid);
 

--- a/src/main/java/de/aservo/confapi/confluence/rest/api/BackupResource.java
+++ b/src/main/java/de/aservo/confapi/confluence/rest/api/BackupResource.java
@@ -21,6 +21,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.UUID;
 
 public interface BackupResource {
 
@@ -96,6 +97,6 @@ public interface BackupResource {
             }
     )
     Response getQueue(
-            @Nonnull @PathParam("uuid") final String uuid);
+            @Nonnull @PathParam("uuid") final UUID uuid);
 
 }

--- a/src/main/java/de/aservo/confapi/confluence/service/BackupServiceImpl.java
+++ b/src/main/java/de/aservo/confapi/confluence/service/BackupServiceImpl.java
@@ -42,6 +42,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Properties;
+import java.util.UUID;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -152,9 +153,9 @@ public class BackupServiceImpl implements BackupService {
 
     @Override
     public BackupQueueBean getQueue(
-            final String uuid) {
+            final UUID uuid) {
 
-        final LongRunningTaskId taskId = LongRunningTaskId.valueOf(uuid);
+        final LongRunningTaskId taskId = LongRunningTaskId.valueOf(uuid.toString());
         final LongRunningTask task = longRunningTaskManager.getLongRunningTask(getUser(), taskId);
         log.info("Trying to get queue information for task with uuid '{}'", uuid);
 

--- a/src/main/java/de/aservo/confapi/confluence/service/api/BackupService.java
+++ b/src/main/java/de/aservo/confapi/confluence/service/api/BackupService.java
@@ -5,6 +5,7 @@ import de.aservo.confapi.confluence.model.BackupQueueBean;
 
 import java.io.File;
 import java.net.URI;
+import java.util.UUID;
 
 public interface BackupService {
 
@@ -21,6 +22,6 @@ public interface BackupService {
             File filePart);
 
     BackupQueueBean getQueue(
-            String uuid);
+            UUID uuid);
 
 }

--- a/src/test/java/de/aservo/confapi/confluence/rest/BackupResourceTest.java
+++ b/src/test/java/de/aservo/confapi/confluence/rest/BackupResourceTest.java
@@ -18,6 +18,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import javax.ws.rs.core.Response;
 import java.io.File;
 import java.net.URI;
+import java.util.UUID;
 
 import static javax.ws.rs.core.Response.Status.*;
 import static org.easymock.EasyMock.expect;
@@ -30,8 +31,8 @@ import static org.mockito.Mockito.mock;
 @PrepareForTest({HttpUtil.class, FilePartUtil.class})
 public class BackupResourceTest {
 
-    private static final URI BACKUP_ZIP_URI = URI.create("http://localhost:1990/confluence/space-export.zip");
     private static final URI BACKUP_QUEUE_URI = URI.create("http://localhost:1990/confluence/rest/confapi/1/backup/queue/123");
+    private static final UUID BACKUP_QUEUE_UUID = UUID.fromString("a0b1cdef-0a12-3bcd-45e6-0a1bcd2345ef");
     private static final String RESPONSE_METADATA_LOCATION = "Location";
 
     @Mock
@@ -115,7 +116,7 @@ public class BackupResourceTest {
         backupQueueBean.setPercentageComplete(50);
         doReturn(backupQueueBean).when(backupService).getQueue(any());
 
-        final Response response = backupResource.getQueue("123");
+        final Response response = backupResource.getQueue(BACKUP_QUEUE_UUID);
         assertEquals(OK.getStatusCode(), response.getStatus());
     }
 
@@ -126,7 +127,7 @@ public class BackupResourceTest {
         backupQueueBean.setEntityUrl(BACKUP_QUEUE_URI);
         doReturn(backupQueueBean).when(backupService).getQueue(any());
 
-        final Response response = backupResource.getQueue("123");
+        final Response response = backupResource.getQueue(BACKUP_QUEUE_UUID);
         assertEquals(CREATED.getStatusCode(), response.getStatus());
         assertNotNull(response.getMetadata().getFirst(RESPONSE_METADATA_LOCATION));
     }
@@ -137,14 +138,14 @@ public class BackupResourceTest {
         backupQueueBean.setPercentageComplete(100);
         doReturn(backupQueueBean).when(backupService).getQueue(any());
 
-        final Response response = backupResource.getQueue("123");
+        final Response response = backupResource.getQueue(BACKUP_QUEUE_UUID);
         assertEquals(CREATED.getStatusCode(), response.getStatus());
         assertNull(response.getMetadata().getFirst(RESPONSE_METADATA_LOCATION));
     }
 
     @Test
     public void testGetQueueUuidNotFound() {
-        final Response response = backupResource.getQueue("123");
+        final Response response = backupResource.getQueue(BACKUP_QUEUE_UUID);
         assertEquals(NOT_FOUND.getStatusCode(), response.getStatus());
     }
 

--- a/src/test/java/de/aservo/confapi/confluence/service/BackupServiceTest.java
+++ b/src/test/java/de/aservo/confapi/confluence/service/BackupServiceTest.java
@@ -43,6 +43,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.UUID;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -63,7 +64,7 @@ public class BackupServiceTest {
     private static final String EXPORT_ZIP_PATH = "space-export.zip";
     private static final URI EXPORT_ZIP_URI = URI.create(BASE_URL + "/" + EXPORT_ZIP_PATH);
 
-    private static final String BACKUP_QUEUE_UUID = "a0b1cdef-0a12-3bcd-45e6-0a1bcd2345ef";
+    private static final UUID BACKUP_QUEUE_UUID = UUID.fromString("a0b1cdef-0a12-3bcd-45e6-0a1bcd2345ef");
     private static final URI BACKUP_QUEUE_URI = URI.create(BASE_URL + "/rest/confapi/1/backup/queue/" + BACKUP_QUEUE_UUID);
 
     @Mock
@@ -140,13 +141,13 @@ public class BackupServiceTest {
         doReturn(task).when(spy).createExportSpaceLongRunningTask(any(ExportContext.class));
 
         final ConfluenceUser user = mock(ConfluenceUser.class);
-        final LongRunningTaskId longRunningTaskId = LongRunningTaskId.valueOf(BACKUP_QUEUE_UUID);
+        final LongRunningTaskId longRunningTaskId = LongRunningTaskId.valueOf(BACKUP_QUEUE_UUID.toString());
         doReturn(longRunningTaskId).when(longRunningTaskManager).startLongRunningTask(user, task);
 
         PowerMock.mockStatic(HttpUtil.class);
         expect(HttpUtil.getUser()).andReturn(user);
         expect(HttpUtil.isLongRunningTaskSupported()).andReturn(Boolean.TRUE);
-        expect(HttpUtil.createRestUri(BACKUP, BACKUP_QUEUE, BACKUP_QUEUE_UUID)).andReturn(BACKUP_QUEUE_URI);
+        expect(HttpUtil.createRestUri(BACKUP, BACKUP_QUEUE, BACKUP_QUEUE_UUID.toString())).andReturn(BACKUP_QUEUE_URI);
         PowerMock.replay(HttpUtil.class);
 
         final BackupBean backupBean = new BackupBean();
@@ -184,12 +185,12 @@ public class BackupServiceTest {
         doReturn(task).when(spy).createImportLongRunningTask(importContext);
 
         final ConfluenceUser user = mock(ConfluenceUser.class);
-        final LongRunningTaskId longRunningTaskId = LongRunningTaskId.valueOf(BACKUP_QUEUE_UUID);
+        final LongRunningTaskId longRunningTaskId = LongRunningTaskId.valueOf(BACKUP_QUEUE_UUID.toString());
         doReturn(longRunningTaskId).when(longRunningTaskManager).startLongRunningTask(user, task);
 
         PowerMock.mockStatic(HttpUtil.class);
         expect(HttpUtil.getUser()).andReturn(user);
-        expect(HttpUtil.createRestUri(BACKUP, BACKUP_QUEUE, BACKUP_QUEUE_UUID)).andReturn(BACKUP_QUEUE_URI);
+        expect(HttpUtil.createRestUri(BACKUP, BACKUP_QUEUE, BACKUP_QUEUE_UUID.toString())).andReturn(BACKUP_QUEUE_URI);
         PowerMock.replay(HttpUtil.class);
 
         assertEquals(BACKUP_QUEUE_URI, spy.doImportAsynchronously(file));
@@ -199,7 +200,7 @@ public class BackupServiceTest {
 
     @Test
     public void testGetQueueExportIncomplete() {
-        final LongRunningTaskId longRunningTaskId = LongRunningTaskId.valueOf(BACKUP_QUEUE_UUID);
+        final LongRunningTaskId longRunningTaskId = LongRunningTaskId.valueOf(BACKUP_QUEUE_UUID.toString());
         final ConfluenceUser user = mock(ConfluenceUser.class);
 
         final ExportSpaceLongRunningTask task = mock(ExportSpaceLongRunningTask.class);
@@ -216,7 +217,7 @@ public class BackupServiceTest {
 
     @Test
     public void testGetQueueExportCompleteAndSuccessful() {
-        final LongRunningTaskId longRunningTaskId = LongRunningTaskId.valueOf(BACKUP_QUEUE_UUID);
+        final LongRunningTaskId longRunningTaskId = LongRunningTaskId.valueOf(BACKUP_QUEUE_UUID.toString());
         final ConfluenceUser user = mock(ConfluenceUser.class);
 
         final ExportSpaceLongRunningTask task = mock(ExportSpaceLongRunningTask.class);
@@ -239,7 +240,7 @@ public class BackupServiceTest {
 
     @Test
     public void testGetQueueImportIncomplete() {
-        final LongRunningTaskId longRunningTaskId = LongRunningTaskId.valueOf(BACKUP_QUEUE_UUID);
+        final LongRunningTaskId longRunningTaskId = LongRunningTaskId.valueOf(BACKUP_QUEUE_UUID.toString());
         final ConfluenceUser user = mock(ConfluenceUser.class);
 
         final ImportLongRunningTask task = mock(ImportLongRunningTask.class);
@@ -256,7 +257,7 @@ public class BackupServiceTest {
 
     @Test
     public void testGetQueueImportCompleteAndSuccessful() {
-        final LongRunningTaskId longRunningTaskId = LongRunningTaskId.valueOf(BACKUP_QUEUE_UUID);
+        final LongRunningTaskId longRunningTaskId = LongRunningTaskId.valueOf(BACKUP_QUEUE_UUID.toString());
         final ConfluenceUser user = mock(ConfluenceUser.class);
 
         final ImportLongRunningTask task = mock(ImportLongRunningTask.class);
@@ -291,7 +292,7 @@ public class BackupServiceTest {
 
     @Test(expected = BadRequestException.class)
     public void testGetQueueNotExportOrImportTask() {
-        final LongRunningTaskId longRunningTaskId = LongRunningTaskId.valueOf(BACKUP_QUEUE_UUID);
+        final LongRunningTaskId longRunningTaskId = LongRunningTaskId.valueOf(BACKUP_QUEUE_UUID.toString());
         final ConfluenceUser user = mock(ConfluenceUser.class);
 
         final LongRunningTask task = mock(LongRunningTask.class);
@@ -306,7 +307,7 @@ public class BackupServiceTest {
 
     @Test(expected = InternalServerErrorException.class)
     public void testGetQueueCompleteButUnsuccessful() {
-        final LongRunningTaskId longRunningTaskId = LongRunningTaskId.valueOf(BACKUP_QUEUE_UUID);
+        final LongRunningTaskId longRunningTaskId = LongRunningTaskId.valueOf(BACKUP_QUEUE_UUID.toString());
         final ConfluenceUser user = mock(ConfluenceUser.class);
 
         final ExportSpaceLongRunningTask task = mock(ExportSpaceLongRunningTask.class);


### PR DESCRIPTION
Hab mal Backup Resouce und Service umgestellt, um auch `java.util.UUID` statt String zu nutzen, wo eine UUID erwartet wird.