### PR TITLE
Fix backup exports and allow forcing synchronous exports

### DIFF
--- a/index.adoc
+++ b/index.adoc
@@ -715,6 +715,18 @@ Initiates an asynchronous import if enabled by server, synchronous otherwise
 |===         
 |Name| Description| Required| Default| Pattern
 
+| formField 
+|  <<boolean>> 
+| - 
+| null 
+|  
+
+| contentType 
+|  <<string>> 
+| - 
+| null 
+|  
+
 | name 
 |  <<string>> 
 | - 
@@ -735,18 +747,6 @@ Initiates an asynchronous import if enabled by server, synchronous otherwise
 
 | inputStream 
 |  <<object>> 
-| - 
-| null 
-|  
-
-| contentType 
-|  <<string>> 
-| - 
-| null 
-|  
-
-| formField 
-|  <<boolean>> 
 | - 
 | null 
 |  
@@ -847,6 +847,19 @@ Initiates an asynchronous export if enabled by server, synchronous otherwise
 
 
 
+====== Query Parameters
+
+[cols="2,3,1,1,1"]
+|===         
+|Name| Description| Required| Default| Pattern
+
+| force-synchronous 
+|   
+| - 
+| false 
+|  
+
+|===         
 
 
 ===== Return Type
@@ -940,6 +953,19 @@ Same as export but especially for the most common case: Single space export with
 
 
 
+====== Query Parameters
+
+[cols="2,3,1,1,1"]
+|===         
+|Name| Description| Required| Default| Pattern
+
+| force-synchronous 
+|   
+| - 
+| false 
+|  
+
+|===         
 
 
 ===== Return Type
@@ -4426,6 +4452,18 @@ endif::internal-generation[]
 |===         
 | Field Name| Required| Type| Description| Format
 
+| formField 
+|  
+| Boolean  
+| 
+|  
+
+| contentType 
+|  
+| String  
+| 
+|  
+
 | name 
 |  
 | String  
@@ -4447,18 +4485,6 @@ endif::internal-generation[]
 | inputStream 
 |  
 | Object  
-| 
-|  
-
-| contentType 
-|  
-| String  
-| 
-|  
-
-| formField 
-|  
-| Boolean  
 | 
 |  
 

--- a/src/main/java/de/aservo/confapi/confluence/rest/BackupResourceImpl.java
+++ b/src/main/java/de/aservo/confapi/confluence/rest/BackupResourceImpl.java
@@ -37,9 +37,10 @@ public class BackupResourceImpl implements BackupResource {
 
     @Override
     public Response getExport(
+            final boolean forceSynchronous,
             @Nonnull final BackupBean backupBean) {
 
-        if (isLongRunningTaskSupported()) {
+        if (isLongRunningTaskSupported() && !forceSynchronous) {
             return Response.status(ACCEPTED)
                     .location(backupService.getExportAsynchronously(backupBean))
                     .build();
@@ -52,6 +53,7 @@ public class BackupResourceImpl implements BackupResource {
 
     @Override
     public Response getExportByKey(
+            final boolean forceSynchronous,
             @Nonnull final String key) {
 
         final BackupBean backupBean = new BackupBean();
@@ -59,7 +61,7 @@ public class BackupResourceImpl implements BackupResource {
         backupBean.setBackupAttachments(true);
         backupBean.setBackupComments(true);
 
-        return getExport(backupBean);
+        return getExport(forceSynchronous, backupBean);
     }
 
     public Response doImportByFileUpload(

--- a/src/main/java/de/aservo/confapi/confluence/rest/api/BackupResource.java
+++ b/src/main/java/de/aservo/confapi/confluence/rest/api/BackupResource.java
@@ -14,11 +14,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 import javax.annotation.Nonnull;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.UUID;
@@ -40,6 +42,7 @@ public interface BackupResource {
             }
     )
     Response getExport(
+            @QueryParam("force-synchronous") @DefaultValue("false") final boolean forceSynchronous,
             @Nonnull final BackupBean backupBean);
 
     @GET
@@ -56,6 +59,7 @@ public interface BackupResource {
             }
     )
     Response getExportByKey(
+            @QueryParam("force-synchronous") @DefaultValue("false") final boolean forceSynchronous,
             @Nonnull @PathParam("key") String key);
 
     @POST

--- a/src/main/java/de/aservo/confapi/confluence/service/BackupServiceImpl.java
+++ b/src/main/java/de/aservo/confapi/confluence/service/BackupServiceImpl.java
@@ -243,7 +243,7 @@ public class BackupServiceImpl implements BackupService {
                 spaceManager,
                 exportContext.getSpaceKeyOfSpaceExport(),
                 exportContext.getType(),
-                null);
+                "all");
     }
 
     private DownloadGateKeeper createDownloadGateKeeper() {

--- a/src/test/java/de/aservo/confapi/confluence/rest/BackupResourceTest.java
+++ b/src/test/java/de/aservo/confapi/confluence/rest/BackupResourceTest.java
@@ -55,7 +55,7 @@ public class BackupResourceTest {
 
         doReturn(BACKUP_QUEUE_URI).when(backupService).getExportAsynchronously(any(BackupBean.class));
 
-        final Response response = backupResource.getExportByKey("space");
+        final Response response = backupResource.getExportByKey(false, "space");
         assertEquals(ACCEPTED.getStatusCode(), response.getStatus());
         assertNotNull(response.getMetadata().getFirst(RESPONSE_METADATA_LOCATION));
     }
@@ -68,7 +68,20 @@ public class BackupResourceTest {
 
         doReturn(BACKUP_QUEUE_URI).when(backupService).getExportSynchronously(any(BackupBean.class));
 
-        final Response response = backupResource.getExportByKey("space");
+        final Response response = backupResource.getExportByKey(false, "space");
+        assertEquals(CREATED.getStatusCode(), response.getStatus());
+        assertNotNull(response.getMetadata().getFirst(RESPONSE_METADATA_LOCATION));
+    }
+
+    @Test
+    public void testGetExportSynchronouslyForced() {
+        PowerMock.mockStatic(HttpUtil.class);
+        expect(HttpUtil.isLongRunningTaskSupported()).andReturn(Boolean.TRUE);
+        PowerMock.replay(HttpUtil.class);
+
+        doReturn(BACKUP_QUEUE_URI).when(backupService).getExportSynchronously(any(BackupBean.class));
+
+        final Response response = backupResource.getExportByKey(true, "space");
         assertEquals(CREATED.getStatusCode(), response.getStatus());
         assertNotNull(response.getMetadata().getFirst(RESPONSE_METADATA_LOCATION));
     }


### PR DESCRIPTION
Diese "all" contentOption hat gefehlt für korrekte Exports, die Synchron-Option wird u.a. für Tests benötigt.