### PR TITLE
Add application link update method

### DIFF
--- a/index.adoc
+++ b/index.adoc
@@ -721,12 +721,6 @@ Initiates an asynchronous import if enabled by server, synchronous otherwise
 | null 
 |  
 
-| contentType 
-|  <<string>> 
-| - 
-| null 
-|  
-
 | name 
 |  <<string>> 
 | - 
@@ -747,6 +741,12 @@ Initiates an asynchronous import if enabled by server, synchronous otherwise
 
 | inputStream 
 |  <<object>> 
+| - 
+| null 
+|  
+
+| contentType 
+|  <<string>> 
 | - 
 | null 
 |  
@@ -4472,36 +4472,6 @@ endif::internal-generation[]
 | 
 | date-time 
 
-| server 
-|  
-| DirectoryLdapServer  
-| 
-|  
-
-| permissions 
-|  
-| DirectoryLdapPermissions  
-| 
-|  
-
-| advanced 
-|  
-| DirectoryInternalAdvanced  
-| 
-|  
-
-| credentialPolicy 
-|  
-| DirectoryInternalCredentialPolicy  
-| 
-|  
-
-| schema 
-|  
-| DirectoryLdapSchema  
-| 
-|  
-
 |===
 
 
@@ -5425,12 +5395,6 @@ endif::internal-generation[]
 | 
 |  
 
-| contentType 
-|  
-| String  
-| 
-|  
-
 | name 
 |  
 | String  
@@ -5452,6 +5416,12 @@ endif::internal-generation[]
 | inputStream 
 |  
 | Object  
+| 
+|  
+
+| contentType 
+|  
+| String  
 | 
 |  
 

--- a/src/test/java/de/aservo/confapi/confluence/service/ApplicationLinkServiceTest.java
+++ b/src/test/java/de/aservo/confapi/confluence/service/ApplicationLinkServiceTest.java
@@ -100,13 +100,14 @@ public class ApplicationLinkServiceTest {
 
     @Test
     public void testSetApplicationLinks()
-            throws URISyntaxException, NoAccessException, NoSuchApplinkException {
+            throws URISyntaxException, NoAccessException, NoSuchApplinkException, TypeNotInstalledException {
 
         ApplicationLink applicationLink = createApplicationLink();
         ApplicationLinkBean applicationLinkBean = createApplicationLinkBean();
         ApplicationLinksBean applicationLinksBean = new ApplicationLinksBean(Collections.singletonList(createApplicationLinkBean()));
 
         doReturn(Collections.singletonList(applicationLink)).when(mutatingApplicationLinkService).getApplicationLinks();
+        doReturn(applicationLink).when(mutatingApplicationLinkService).getApplicationLink(any());
         doReturn(applicationLink).when(mutatingApplicationLinkService).addApplicationLink(any(), any(), any());
         doReturn(new DefaultApplicationType()).when(typeAccessor).getApplicationType(any());
         doReturn(createApplinkStatus(applicationLink, AVAILABLE)).when(applinkStatusService).getApplinkStatus(any());
@@ -118,16 +119,35 @@ public class ApplicationLinkServiceTest {
 
     @Test
     public void testSetApplicationLink()
-            throws URISyntaxException, NoAccessException, NoSuchApplinkException {
+            throws URISyntaxException, NoAccessException, NoSuchApplinkException, TypeNotInstalledException {
 
         ApplicationLink applicationLink = createApplicationLink();
         ApplicationLinkBean applicationLinkBean = createApplicationLinkBean();
 
+        doReturn(applicationLink).when(mutatingApplicationLinkService).getApplicationLink(any());
         doReturn(applicationLink).when(mutatingApplicationLinkService).addApplicationLink(any(), any(), any());
         doReturn(new DefaultApplicationType()).when(typeAccessor).getApplicationType(any());
         doReturn(createApplinkStatus(applicationLink, AVAILABLE)).when(applinkStatusService).getApplinkStatus(any());
 
         ApplicationLinkBean applicationLinkResponse = applicationLinkService.setApplicationLink(UUID.randomUUID(), applicationLinkBean, true);
+
+        assertEquals(applicationLinkBean.getName(), applicationLinkResponse.getName());
+    }
+
+    @Test
+    public void testSetApplicationLinkUpdate()
+            throws URISyntaxException, NoAccessException, NoSuchApplinkException, TypeNotInstalledException {
+
+        ApplicationLink applicationLink = createApplicationLink();
+        ApplicationLinkBean applicationLinkBean = createApplicationLinkBeanUpdate();
+
+        ApplicationLinkServiceImpl spyApplicationLinkService = spy(applicationLinkService);
+        doReturn(applicationLink.getType()).when(spyApplicationLinkService).buildApplicationType(any());
+
+        doReturn(applicationLink).when(mutatingApplicationLinkService).getApplicationLink(any());
+        doReturn(createApplinkStatus(applicationLink, AVAILABLE)).when(applinkStatusService).getApplinkStatus(any());
+
+        ApplicationLinkBean applicationLinkResponse = spyApplicationLinkService.setApplicationLink(UUID.randomUUID(), applicationLinkBean, true);
 
         assertEquals(applicationLinkBean.getName(), applicationLinkResponse.getName());
     }
@@ -248,6 +268,12 @@ public class ApplicationLinkServiceTest {
         bean.setType(CROWD);
         bean.setUsername("test");
         bean.setPassword("test");
+        return bean;
+    }
+
+    private ApplicationLinkBean createApplicationLinkBeanUpdate() throws URISyntaxException {
+        ApplicationLinkBean bean = ApplicationLinkBeanUtil.toApplicationLinkBean(createApplicationLink());
+        bean.setType(CROWD);
         return bean;
     }
 


### PR DESCRIPTION
When authentication information/applicaiton link id and type remain the same, there is no need to delete and add an application link, it suffices to update the linkDetails.