### PR TITLE
Removed bug discarding all gadgets as invalid.

### DIFF
--- a/index.adoc
+++ b/index.adoc
@@ -715,12 +715,6 @@ Initiates an asynchronous import if enabled by server, synchronous otherwise
 |===         
 |Name| Description| Required| Default| Pattern
 
-| contentType 
-|  <<string>> 
-| - 
-| null 
-|  
-
 | name 
 |  <<string>> 
 | - 
@@ -741,6 +735,12 @@ Initiates an asynchronous import if enabled by server, synchronous otherwise
 
 | inputStream 
 |  <<object>> 
+| - 
+| null 
+|  
+
+| contentType 
+|  <<string>> 
 | - 
 | null 
 |  
@@ -4472,6 +4472,36 @@ endif::internal-generation[]
 | 
 | date-time 
 
+| server 
+|  
+| DirectoryLdapServer  
+| 
+|  
+
+| permissions 
+|  
+| DirectoryLdapPermissions  
+| 
+|  
+
+| advanced 
+|  
+| DirectoryInternalAdvanced  
+| 
+|  
+
+| credentialPolicy 
+|  
+| DirectoryInternalCredentialPolicy  
+| 
+|  
+
+| schema 
+|  
+| DirectoryLdapSchema  
+| 
+|  
+
 |===
 
 
@@ -5389,12 +5419,6 @@ endif::internal-generation[]
 |===         
 | Field Name| Required| Type| Description| Format
 
-| contentType 
-|  
-| String  
-| 
-|  
-
 | name 
 |  
 | String  
@@ -5416,6 +5440,12 @@ endif::internal-generation[]
 | inputStream 
 |  
 | Object  
+| 
+|  
+
+| contentType 
+|  
+| String  
 | 
 |  
 


### PR DESCRIPTION
addGadget method in GadgetServiceImpl always throws error for totally valid gadgets even for a clean instance. The method can add gadgets only after successfully adding the same gadget on the web UI. 

Workaround:
Moved the check for valid gadget URL after adding the gadget, and deleting the gadget at the end if invalid.