### PR TITLE
Update JUnit and Mockito to versions 5.x, replace PowerMock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,6 @@
         <javax.el-api.version>3.0.0</javax.el-api.version>
         <log4j.version>2.8.2</log4j.version>
         <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
-        <powermock-api-easymock.version>2.0.7</powermock-api-easymock.version>
         <slf4j.version>1.7.30</slf4j.version>
     </properties>
 
@@ -295,20 +294,6 @@
             <groupId>com.atlassian.plugins</groupId>
             <artifactId>atlassian-plugins-osgi-testrunner</artifactId>
             <version>${plugin.testrunner.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-easymock</artifactId>
-            <version>${powermock-api-easymock.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock-api-easymock.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
             <!-- not working, use for version references -->
             <dependency>
                 <groupId>com.atlassian.confluence</groupId>
@@ -94,10 +95,19 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
             <dependency>
                 <groupId>de.aservo</groupId>
                 <artifactId>confapi-commons</artifactId>
                 <version>${confapi-commons.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.10.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -126,6 +136,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <version>1.18.28</version>
             <scope>provided</scope>
         </dependency>
 
@@ -249,14 +260,15 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <version>5.10.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -312,14 +324,6 @@
             <artifactId>slf4j-simple</artifactId>
             <version>${slf4j.version}</version>
             <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jacoco</groupId>
-            <artifactId>org.jacoco.agent</artifactId>
-            <classifier>runtime</classifier>
-            <scope>test</scope>
-            <version>0.8.5</version>
         </dependency>
 
     </dependencies>

--- a/src/test/java/de/aservo/confapi/confluence/filter/SysAdminOnlyResourceFilterTest.java
+++ b/src/test/java/de/aservo/confapi/confluence/filter/SysAdminOnlyResourceFilterTest.java
@@ -15,7 +15,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/de/aservo/confapi/confluence/rest/BackupResourceTest.java
+++ b/src/test/java/de/aservo/confapi/confluence/rest/BackupResourceTest.java
@@ -4,16 +4,13 @@ import com.atlassian.plugins.rest.common.multipart.FilePart;
 import de.aservo.confapi.confluence.model.BackupBean;
 import de.aservo.confapi.confluence.model.BackupQueueBean;
 import de.aservo.confapi.confluence.service.api.BackupService;
-import de.aservo.confapi.confluence.util.FilePartUtil;
 import de.aservo.confapi.confluence.util.HttpUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.ws.rs.core.Response;
 import java.io.File;
@@ -21,14 +18,11 @@ import java.net.URI;
 import java.util.UUID;
 
 import static javax.ws.rs.core.Response.Status.*;
-import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({HttpUtil.class, FilePartUtil.class})
+@RunWith(MockitoJUnitRunner.class)
 public class BackupResourceTest {
 
     private static final URI BACKUP_QUEUE_URI = URI.create("http://localhost:1990/confluence/rest/confapi/1/backup/queue/123");
@@ -42,85 +36,75 @@ public class BackupResourceTest {
 
     @Before
     public void setup() {
-        MockitoAnnotations.initMocks(this);
-
         backupResource = new BackupResourceImpl(backupService);
     }
 
     @Test
     public void testGetExportAsynchronously() {
-        PowerMock.mockStatic(HttpUtil.class);
-        expect(HttpUtil.isLongRunningTaskSupported()).andReturn(Boolean.TRUE);
-        PowerMock.replay(HttpUtil.class);
-
         doReturn(BACKUP_QUEUE_URI).when(backupService).getExportAsynchronously(any(BackupBean.class));
 
-        final Response response = backupResource.getExportByKey(false, "space");
-        assertEquals(ACCEPTED.getStatusCode(), response.getStatus());
-        assertNotNull(response.getMetadata().getFirst(RESPONSE_METADATA_LOCATION));
+        try (MockedStatic<HttpUtil> httpUtilMockedStatic = mockStatic(HttpUtil.class)) {
+            httpUtilMockedStatic.when(HttpUtil::isLongRunningTaskSupported).thenReturn(true);
+
+            final Response response = backupResource.getExportByKey(false, "space");
+            assertEquals(ACCEPTED.getStatusCode(), response.getStatus());
+            assertNotNull(response.getMetadata().getFirst(RESPONSE_METADATA_LOCATION));
+        }
     }
 
     @Test
     public void testGetExportSynchronously() {
-        PowerMock.mockStatic(HttpUtil.class);
-        expect(HttpUtil.isLongRunningTaskSupported()).andReturn(Boolean.FALSE);
-        PowerMock.replay(HttpUtil.class);
-
         doReturn(BACKUP_QUEUE_URI).when(backupService).getExportSynchronously(any(BackupBean.class));
 
-        final Response response = backupResource.getExportByKey(false, "space");
-        assertEquals(CREATED.getStatusCode(), response.getStatus());
-        assertNotNull(response.getMetadata().getFirst(RESPONSE_METADATA_LOCATION));
+        try (MockedStatic<HttpUtil> httpUtilMockedStatic = mockStatic(HttpUtil.class)) {
+            httpUtilMockedStatic.when(HttpUtil::isLongRunningTaskSupported).thenReturn(true);
+
+            final Response response = backupResource.getExportByKey(false, "space");
+            assertEquals(CREATED.getStatusCode(), response.getStatus());
+            assertNotNull(response.getMetadata().getFirst(RESPONSE_METADATA_LOCATION));
+        }
     }
 
     @Test
     public void testGetExportSynchronouslyForced() {
-        PowerMock.mockStatic(HttpUtil.class);
-        expect(HttpUtil.isLongRunningTaskSupported()).andReturn(Boolean.TRUE);
-        PowerMock.replay(HttpUtil.class);
-
         doReturn(BACKUP_QUEUE_URI).when(backupService).getExportSynchronously(any(BackupBean.class));
 
-        final Response response = backupResource.getExportByKey(true, "space");
-        assertEquals(CREATED.getStatusCode(), response.getStatus());
-        assertNotNull(response.getMetadata().getFirst(RESPONSE_METADATA_LOCATION));
+        try (MockedStatic<HttpUtil> httpUtilMockedStatic = mockStatic(HttpUtil.class)) {
+            httpUtilMockedStatic.when(HttpUtil::isLongRunningTaskSupported).thenReturn(true);
+
+            final Response response = backupResource.getExportByKey(true, "space");
+            assertEquals(CREATED.getStatusCode(), response.getStatus());
+            assertNotNull(response.getMetadata().getFirst(RESPONSE_METADATA_LOCATION));
+        }
     }
 
     @Test
     public void testDoImportByUploadAsynchronously() {
-        PowerMock.mockStatic(HttpUtil.class);
-        expect(HttpUtil.isLongRunningTaskSupported()).andReturn(Boolean.TRUE);
-        PowerMock.replay(HttpUtil.class);
-
         final FilePart filePart = mock(FilePart.class);
         final File file = mock(File.class);
 
-        PowerMock.mockStatic(FilePartUtil.class);
-        expect(FilePartUtil.createFile(filePart)).andReturn(file);
-        PowerMock.replay(FilePartUtil.class);
-
         doReturn(BACKUP_QUEUE_URI).when(backupService).doImportAsynchronously(file);
 
-        final Response response = backupResource.doImportByFileUpload(filePart);
-        assertEquals(ACCEPTED.getStatusCode(), response.getStatus());
-        assertNotNull(response.getMetadata().getFirst(RESPONSE_METADATA_LOCATION));
+        try (MockedStatic<HttpUtil> httpUtilMockedStatic = mockStatic(HttpUtil.class)) {
+            httpUtilMockedStatic.when(HttpUtil::isLongRunningTaskSupported).thenReturn(true);
+
+            final Response response = backupResource.doImportByFileUpload(filePart);
+            assertEquals(ACCEPTED.getStatusCode(), response.getStatus());
+            assertNotNull(response.getMetadata().getFirst(RESPONSE_METADATA_LOCATION));
+        }
     }
 
     @Test
     public void testDoImportByUploadSynchronously() {
-        PowerMock.mockStatic(HttpUtil.class);
-        expect(HttpUtil.isLongRunningTaskSupported()).andReturn(Boolean.FALSE);
-        PowerMock.replay(HttpUtil.class);
-
         final FilePart filePart = mock(FilePart.class);
         final File file = mock(File.class);
 
-        PowerMock.mockStatic(FilePartUtil.class);
-        expect(FilePartUtil.createFile(filePart)).andReturn(file);
-        PowerMock.replay(FilePartUtil.class);
+        try (MockedStatic<HttpUtil> httpUtilMockedStatic = mockStatic(HttpUtil.class)) {
+            httpUtilMockedStatic.when(HttpUtil::isLongRunningTaskSupported).thenReturn(true);
 
-        final Response response = backupResource.doImportByFileUpload(filePart);
-        assertEquals(CREATED.getStatusCode(), response.getStatus());
+            final Response response = backupResource.doImportByFileUpload(filePart);
+            assertEquals(CREATED.getStatusCode(), response.getStatus());
+        }
     }
 
     @Test

--- a/src/test/java/de/aservo/confapi/confluence/service/ApplicationLinkServiceTest.java
+++ b/src/test/java/de/aservo/confapi/confluence/service/ApplicationLinkServiceTest.java
@@ -43,7 +43,7 @@ import static de.aservo.confapi.commons.model.ApplicationLinkBean.ApplicationLin
 import static de.aservo.confapi.commons.model.ApplicationLinkBean.ApplicationLinkStatus.CONFIGURATION_ERROR;
 import static de.aservo.confapi.commons.model.ApplicationLinkBean.ApplicationLinkType.CROWD;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/de/aservo/confapi/confluence/service/DirectoryServiceTest.java
+++ b/src/test/java/de/aservo/confapi/confluence/service/DirectoryServiceTest.java
@@ -31,7 +31,7 @@ import static com.atlassian.crowd.directory.SynchronisableDirectoryProperties.Sy
 import static com.atlassian.crowd.model.directory.DirectoryImpl.ATTRIBUTE_KEY_USE_NESTED_GROUPS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/de/aservo/confapi/confluence/service/GadgetsServiceTest.java
+++ b/src/test/java/de/aservo/confapi/confluence/service/GadgetsServiceTest.java
@@ -21,9 +21,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -31,29 +30,27 @@ import java.util.Collections;
 import java.util.Locale;
 import java.util.UUID;
 
-import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-//power mockito required here for mocking static methods of AuthenticatedUserThreadLocal
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(AuthenticatedUserThreadLocal.class)
+@RunWith(MockitoJUnitRunner.class)
 public class GadgetsServiceTest {
 
     @Mock
     private ExternalGadgetSpecStore externalGadgetSpecStore;
+
+    @Mock
     private GadgetSpecFactory gadgetSpecFactory;
+
+    @Mock
     private LocaleManager localeManager;
 
     private GadgetsService gadgetsService;
 
     @Before
     public void setup() {
-        externalGadgetSpecStore = mock(ExternalGadgetSpecStore.class);
-        gadgetSpecFactory = mock(GadgetSpecFactory.class);
-        localeManager = mock(LocaleManager.class);
         gadgetsService = new GadgetsServiceImpl(externalGadgetSpecStore, gadgetSpecFactory, localeManager);
     }
 
@@ -94,15 +91,14 @@ public class GadgetsServiceTest {
 
         GadgetSpec gadgetSpec = GadgetSpec.gadgetSpec(externalGadgetSpec.getSpecUri()).build();
 
-        PowerMock.mockStatic(AuthenticatedUserThreadLocal.class);
-        expect(AuthenticatedUserThreadLocal.get()).andReturn(user);
-        PowerMock.replay(AuthenticatedUserThreadLocal.class);
-
-        doReturn(Locale.GERMAN).when(localeManager).getLocale(user);
         doReturn(gadgetSpec).when(gadgetSpecFactory).getGadgetSpec(externalGadgetSpec.getSpecUri(), null);
 
-        GadgetBean gadgetsBean = gadgetsService.addGadget(gadgetBean);
-        assertEquals(externalGadgetSpec.getSpecUri(), gadgetsBean.getUrl());
+        try (MockedStatic<AuthenticatedUserThreadLocal> authenticatedUserThreadLocalMockedStatic = mockStatic(AuthenticatedUserThreadLocal.class)) {
+            authenticatedUserThreadLocalMockedStatic.when(AuthenticatedUserThreadLocal::get).thenReturn(user);
+
+            final GadgetBean gadgetsBean = gadgetsService.addGadget(gadgetBean);
+            assertEquals(externalGadgetSpec.getSpecUri(), gadgetsBean.getUrl());
+        }
     }
 
     @Test(expected = BadRequestException.class)
@@ -115,14 +111,14 @@ public class GadgetsServiceTest {
         GadgetBean gadgetBean = new GadgetBean();
         gadgetBean.setUrl(externalGadgetSpec.getSpecUri());
 
-        PowerMock.mockStatic(AuthenticatedUserThreadLocal.class);
-        expect(AuthenticatedUserThreadLocal.get()).andReturn(user);
-        PowerMock.replay(AuthenticatedUserThreadLocal.class);
-
         doReturn(Locale.GERMAN).when(localeManager).getLocale(user);
         doThrow(new GadgetParsingException("")).when(gadgetSpecFactory).getGadgetSpec((URI) any(), any());
 
-        gadgetsService.addGadget(gadgetBean);
+        try (MockedStatic<AuthenticatedUserThreadLocal> authenticatedUserThreadLocalMockedStatic = mockStatic(AuthenticatedUserThreadLocal.class)) {
+            authenticatedUserThreadLocalMockedStatic.when(AuthenticatedUserThreadLocal::get).thenReturn(user);
+
+            gadgetsService.addGadget(gadgetBean);
+        }
     }
 
     @Test
@@ -138,15 +134,15 @@ public class GadgetsServiceTest {
 
         GadgetSpec gadgetSpec = GadgetSpec.gadgetSpec(externalGadgetSpec.getSpecUri()).build();
 
-        PowerMock.mockStatic(AuthenticatedUserThreadLocal.class);
-        expect(AuthenticatedUserThreadLocal.get()).andReturn(user);
-        PowerMock.replay(AuthenticatedUserThreadLocal.class);
-
         doReturn(Locale.GERMAN).when(localeManager).getLocale(user);
         doReturn(gadgetSpec).when(gadgetSpecFactory).getGadgetSpec(externalGadgetSpec.getSpecUri(), null);
 
-        GadgetsBean gadgetsBean = gadgetsService.setGadgets(gadgetsBeanToSet);
-        assertEquals(externalGadgetSpec.getSpecUri(), gadgetsBean.getGadgets().iterator().next().getUrl());
+        try (MockedStatic<AuthenticatedUserThreadLocal> authenticatedUserThreadLocalMockedStatic = mockStatic(AuthenticatedUserThreadLocal.class)) {
+            authenticatedUserThreadLocalMockedStatic.when(AuthenticatedUserThreadLocal::get).thenReturn(user);
+
+            final GadgetsBean gadgetsBean = gadgetsService.setGadgets(gadgetsBeanToSet);
+            assertEquals(externalGadgetSpec.getSpecUri(), gadgetsBean.getGadgets().iterator().next().getUrl());
+        }
     }
 
     @Test
@@ -161,15 +157,15 @@ public class GadgetsServiceTest {
         gadgetBean.setUrl(externalGadgetSpec.getSpecUri());
         GadgetSpec gadgetSpec = GadgetSpec.gadgetSpec(externalGadgetSpec.getSpecUri()).build();
 
-        PowerMock.mockStatic(AuthenticatedUserThreadLocal.class);
-        expect(AuthenticatedUserThreadLocal.get()).andReturn(user);
-        PowerMock.replay(AuthenticatedUserThreadLocal.class);
-
         doReturn(Locale.GERMAN).when(localeManager).getLocale(user);
         doReturn(gadgetSpec).when(gadgetSpecFactory).getGadgetSpec(externalGadgetSpec.getSpecUri(), null);
 
-        GadgetBean responseGadgetBean = gadgetsService.setGadget(1L, gadgetBean);
-        assertEquals(externalGadgetSpec.getSpecUri(), responseGadgetBean.getUrl());
+        try (MockedStatic<AuthenticatedUserThreadLocal> authenticatedUserThreadLocalMockedStatic = mockStatic(AuthenticatedUserThreadLocal.class)) {
+            authenticatedUserThreadLocalMockedStatic.when(AuthenticatedUserThreadLocal::get).thenReturn(user);
+
+            GadgetBean responseGadgetBean = gadgetsService.setGadget(1L, gadgetBean);
+            assertEquals(externalGadgetSpec.getSpecUri(), responseGadgetBean.getUrl());
+        }
     }
 
     @Test

--- a/src/test/java/de/aservo/confapi/confluence/service/LicensesServiceTest.java
+++ b/src/test/java/de/aservo/confapi/confluence/service/LicensesServiceTest.java
@@ -14,7 +14,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static com.atlassian.confluence.setup.ConfluenceBootstrapConstants.DEFAULT_LICENSE_REGISTRY_KEY;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 

--- a/src/test/java/de/aservo/confapi/confluence/service/MailServerServiceTest.java
+++ b/src/test/java/de/aservo/confapi/confluence/service/MailServerServiceTest.java
@@ -21,7 +21,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/de/aservo/confapi/confluence/service/SettingsBrandingServiceTest.java
+++ b/src/test/java/de/aservo/confapi/confluence/service/SettingsBrandingServiceTest.java
@@ -15,9 +15,9 @@ import de.aservo.confapi.commons.model.SettingsBrandingColorSchemeBean;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -25,26 +25,27 @@ import java.io.InputStream;
 import java.util.Optional;
 
 import static de.aservo.confapi.confluence.model.util.SettingsBrandingColorSchemeBeanUtil.toGlobalColorScheme;
-import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.*;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(ImageType.class)
+@RunWith(MockitoJUnitRunner.class)
 public class SettingsBrandingServiceTest {
 
+    @Mock
     private ColourSchemeManager colourSchemeManager;
+
+    @Mock
     private FaviconManager faviconManager;
+
+    @Mock
     private SiteLogoManager siteLogoManager;
+
+    @Mock
     private SettingsBrandingServiceImpl settingsBrandingService;
 
     @Before
     public void setup() {
-        //when using powermock we cannot initialize with @Mock or @InjectMocks unfortunately
-        colourSchemeManager = mock(ColourSchemeManager.class);
-        siteLogoManager = mock(SiteLogoManager.class);
-        faviconManager = mock(FaviconManager.class);
         settingsBrandingService = new SettingsBrandingServiceImpl(colourSchemeManager, siteLogoManager, faviconManager);
     }
 
@@ -111,13 +112,12 @@ public class SettingsBrandingServiceTest {
 
         InputStream is = new ByteArrayInputStream("".getBytes());
 
-        PowerMock.mockStatic(ImageType.class);
-        expect(ImageType.parseFromContentType("content/unknown")).andReturn(Optional.of(ImageType.PNG));
-        PowerMock.replay(ImageType.class);
+        try (MockedStatic<ImageType> TODO = mockStatic(ImageType.class)) {
+            TODO.when(() -> ImageType.parseFromContentType("content/unknown")).thenReturn(ImageType.PNG);
 
-        settingsBrandingService.setFavicon(is);
-
-        verify(faviconManager).setFavicon(any());
+            settingsBrandingService.setFavicon(is);
+            verify(faviconManager).setFavicon(any());
+        }
     }
 
     @Test(expected = BadRequestException.class)

--- a/src/test/java/de/aservo/confapi/confluence/util/HttpUtilTest.java
+++ b/src/test/java/de/aservo/confapi/confluence/util/HttpUtilTest.java
@@ -7,9 +7,8 @@ import de.aservo.confapi.commons.exception.InternalServerErrorException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
@@ -17,13 +16,10 @@ import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 
 import static de.aservo.confapi.confluence.util.HttpUtil.SERVLET_CONTEXT_INIT_PARAM_EXPORT_TASK;
-import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({AuthenticatedUserThreadLocal.class, ServletContextThreadLocal.class})
+@RunWith(MockitoJUnitRunner.class)
 public class HttpUtilTest {
 
     private static final String BASE_URL = "http://localhost:1990/confluence";
@@ -43,33 +39,30 @@ public class HttpUtilTest {
 
     @Test
     public void testGetUser() {
-        PowerMock.mockStatic(AuthenticatedUserThreadLocal.class);
-        expect(AuthenticatedUserThreadLocal.get()).andReturn(user);
-        PowerMock.replay(AuthenticatedUserThreadLocal.class);
-
-        assertNotNull(HttpUtil.getUser());
+        try (MockedStatic<AuthenticatedUserThreadLocal> authenticatedUserThreadLocalMockedStatic = mockStatic(AuthenticatedUserThreadLocal.class)) {
+            authenticatedUserThreadLocalMockedStatic.when(AuthenticatedUserThreadLocal::get).thenReturn(user);
+            assertNotNull(HttpUtil.getUser());
+        }
     }
 
     @Test
     public void testGetServletRequest() {
         final HttpServletRequest servletRequest = mock(HttpServletRequest.class);
 
-        PowerMock.mockStatic(ServletContextThreadLocal.class);
-        expect(ServletContextThreadLocal.getRequest()).andReturn(servletRequest);
-        PowerMock.replay(ServletContextThreadLocal.class);
-
-        assertNotNull(HttpUtil.getServletRequest());
+        try (MockedStatic<ServletContextThreadLocal> servletContextThreadLocalMockedStatic = mockStatic(ServletContextThreadLocal.class)) {
+            servletContextThreadLocalMockedStatic.when(ServletContextThreadLocal::getRequest).thenReturn(servletRequest);
+            assertNotNull(HttpUtil.getServletRequest());
+        }
     }
 
     @Test
     public void testGetServletContext() {
         final ServletContext servletContext = mock(ServletContext.class);
 
-        PowerMock.mockStatic(ServletContextThreadLocal.class);
-        expect(ServletContextThreadLocal.getContext()).andReturn(servletContext);
-        PowerMock.replay(ServletContextThreadLocal.class);
-
-        assertNotNull(HttpUtil.getServletContext());
+        try (MockedStatic<ServletContextThreadLocal> servletContextThreadLocalMockedStatic = mockStatic(ServletContextThreadLocal.class)) {
+            servletContextThreadLocalMockedStatic.when(ServletContextThreadLocal::getContext).thenReturn(servletContext);
+            assertNotNull(HttpUtil.getServletContext());
+        }
     }
 
     @Test
@@ -81,11 +74,10 @@ public class HttpUtilTest {
         doReturn(SERVLET_PATH).when(servletRequest).getServletPath();
         doReturn(PATH_INFO).when(servletRequest).getPathInfo();
 
-        PowerMock.mockStatic(ServletContextThreadLocal.class);
-        expect(ServletContextThreadLocal.getRequest()).andReturn(servletRequest).anyTimes();
-        PowerMock.replay(ServletContextThreadLocal.class);
-
-        assertEquals(URI.create(BASE_URL), HttpUtil.getBaseUrl());
+        try (MockedStatic<ServletContextThreadLocal> servletContextThreadLocalMockedStatic = mockStatic(ServletContextThreadLocal.class)) {
+            servletContextThreadLocalMockedStatic.when(ServletContextThreadLocal::getRequest).thenReturn(servletRequest);
+            assertEquals(URI.create(BASE_URL), HttpUtil.getBaseUrl());
+        }
     }
 
     @Test
@@ -96,11 +88,10 @@ public class HttpUtilTest {
         doReturn(new StringBuffer(requestUrl)).when(servletRequest).getRequestURL();
         doReturn(SERVLET_PATH).when(servletRequest).getServletPath();
 
-        PowerMock.mockStatic(ServletContextThreadLocal.class);
-        expect(ServletContextThreadLocal.getRequest()).andReturn(servletRequest).anyTimes();
-        PowerMock.replay(ServletContextThreadLocal.class);
-
-        assertEquals(URI.create(BASE_URL), HttpUtil.getBaseUrl());
+        try (MockedStatic<ServletContextThreadLocal> servletContextThreadLocalMockedStatic = mockStatic(ServletContextThreadLocal.class)) {
+            servletContextThreadLocalMockedStatic.when(ServletContextThreadLocal::getRequest).thenReturn(servletRequest);
+            assertEquals(URI.create(BASE_URL), HttpUtil.getBaseUrl());
+        }
     }
 
     @Test
@@ -108,11 +99,10 @@ public class HttpUtilTest {
         final HttpServletRequest servletRequest = mock(HttpServletRequest.class);
         doReturn(new StringBuffer(BASE_URL)).when(servletRequest).getRequestURL();
 
-        PowerMock.mockStatic(ServletContextThreadLocal.class);
-        expect(ServletContextThreadLocal.getRequest()).andReturn(servletRequest).anyTimes();
-        PowerMock.replay(ServletContextThreadLocal.class);
-
-        assertEquals(URI.create(BASE_URL), HttpUtil.getBaseUrl());
+        try (MockedStatic<ServletContextThreadLocal> servletContextThreadLocalMockedStatic = mockStatic(ServletContextThreadLocal.class)) {
+            servletContextThreadLocalMockedStatic.when(ServletContextThreadLocal::getRequest).thenReturn(servletRequest);
+            assertEquals(URI.create(BASE_URL), HttpUtil.getBaseUrl());
+        }
     }
 
     @Test
@@ -124,13 +114,11 @@ public class HttpUtilTest {
         doReturn(SERVLET_PATH).when(servletRequest).getServletPath();
         doReturn(PATH_INFO).when(servletRequest).getPathInfo();
 
-        PowerMock.mockStatic(ServletContextThreadLocal.class);
-        expect(ServletContextThreadLocal.getRequest()).andReturn(servletRequest).anyTimes();
-        PowerMock.replay(ServletContextThreadLocal.class);
-
-        final URI restUrl = UriBuilder.fromUri(BASE_URL).path(SERVLET_PATH).path(REST_PATH).build();
-
-        assertEquals(restUrl, HttpUtil.getRestUrl());
+        try (MockedStatic<ServletContextThreadLocal> servletContextThreadLocalMockedStatic = mockStatic(ServletContextThreadLocal.class)) {
+            servletContextThreadLocalMockedStatic.when(ServletContextThreadLocal::getRequest).thenReturn(servletRequest);
+            final URI restUrl = UriBuilder.fromUri(BASE_URL).path(SERVLET_PATH).path(REST_PATH).build();
+            assertEquals(restUrl, HttpUtil.getRestUrl());
+        }
     }
 
     @Test(expected = InternalServerErrorException.class)
@@ -138,11 +126,10 @@ public class HttpUtilTest {
         final HttpServletRequest servletRequest = mock(HttpServletRequest.class);
         doReturn(new StringBuffer(BASE_URL)).when(servletRequest).getRequestURL();
 
-        PowerMock.mockStatic(ServletContextThreadLocal.class);
-        expect(ServletContextThreadLocal.getRequest()).andReturn(servletRequest).anyTimes();
-        PowerMock.replay(ServletContextThreadLocal.class);
-
-        HttpUtil.getRestUrl();
+        try (MockedStatic<ServletContextThreadLocal> servletContextThreadLocalMockedStatic = mockStatic(ServletContextThreadLocal.class)) {
+            servletContextThreadLocalMockedStatic.when(ServletContextThreadLocal::getRequest).thenReturn(servletRequest);
+            HttpUtil.getRestUrl();
+        }
     }
 
     @Test(expected = InternalServerErrorException.class)
@@ -155,11 +142,10 @@ public class HttpUtilTest {
         doReturn(SERVLET_PATH_OTHER).when(servletRequest).getServletPath();
         doReturn(filePath).when(servletRequest).getPathInfo();
 
-        PowerMock.mockStatic(ServletContextThreadLocal.class);
-        expect(ServletContextThreadLocal.getRequest()).andReturn(servletRequest).anyTimes();
-        PowerMock.replay(ServletContextThreadLocal.class);
-
-        HttpUtil.getRestUrl();
+        try (MockedStatic<ServletContextThreadLocal> servletContextThreadLocalMockedStatic = mockStatic(ServletContextThreadLocal.class)) {
+            servletContextThreadLocalMockedStatic.when(ServletContextThreadLocal::getRequest).thenReturn(servletRequest);
+            HttpUtil.getRestUrl();
+        }
     }
 
     @Test
@@ -173,12 +159,11 @@ public class HttpUtilTest {
         doReturn(SERVLET_PATH).when(servletRequest).getServletPath();
         doReturn(PATH_INFO).when(servletRequest).getPathInfo();
 
-        PowerMock.mockStatic(ServletContextThreadLocal.class);
-        expect(ServletContextThreadLocal.getRequest()).andReturn(servletRequest).anyTimes();
-        PowerMock.replay(ServletContextThreadLocal.class);
-
-        final URI uri = UriBuilder.fromUri(BASE_URL).path(servlet).path(file).build();
-        assertEquals(uri, HttpUtil.createUri(servlet, file));
+        try (MockedStatic<ServletContextThreadLocal> servletContextThreadLocalMockedStatic = mockStatic(ServletContextThreadLocal.class)) {
+            servletContextThreadLocalMockedStatic.when(ServletContextThreadLocal::getRequest).thenReturn(servletRequest);
+            final URI uri = UriBuilder.fromUri(BASE_URL).path(servlet).path(file).build();
+            assertEquals(uri, HttpUtil.createUri(servlet, file));
+        }
     }
 
     @Test
@@ -190,12 +175,11 @@ public class HttpUtilTest {
         doReturn(SERVLET_PATH).when(servletRequest).getServletPath();
         doReturn(PATH_INFO).when(servletRequest).getPathInfo();
 
-        PowerMock.mockStatic(ServletContextThreadLocal.class);
-        expect(ServletContextThreadLocal.getRequest()).andReturn(servletRequest).anyTimes();
-        PowerMock.replay(ServletContextThreadLocal.class);
-
-        final URI restUri = UriBuilder.fromUri(BASE_URL).path(SERVLET_PATH).path(REST_PATH).path(ENDPOINT_PATH_OTHER).build();
-        assertEquals(restUri, HttpUtil.createRestUri(ENDPOINT_PATH_OTHER));
+        try (MockedStatic<ServletContextThreadLocal> servletContextThreadLocalMockedStatic = mockStatic(ServletContextThreadLocal.class)) {
+            servletContextThreadLocalMockedStatic.when(ServletContextThreadLocal::getRequest).thenReturn(servletRequest);
+            final URI restUri = UriBuilder.fromUri(BASE_URL).path(SERVLET_PATH).path(REST_PATH).path(ENDPOINT_PATH_OTHER).build();
+            assertEquals(restUri, HttpUtil.createRestUri(ENDPOINT_PATH_OTHER));
+        }
     }
 
     @Test
@@ -207,11 +191,10 @@ public class HttpUtilTest {
         doReturn("unsupportedone,otherone").when(servletContext)
                 .getInitParameter(SERVLET_CONTEXT_INIT_PARAM_EXPORT_TASK);
 
-        PowerMock.mockStatic(ServletContextThreadLocal.class);
-        expect(ServletContextThreadLocal.getContext()).andReturn(servletContext).anyTimes();
-        PowerMock.replay(ServletContextThreadLocal.class);
-
-        assertTrue(HttpUtil.isLongRunningTaskSupported());
+        try (MockedStatic<ServletContextThreadLocal> servletContextThreadLocalMockedStatic = mockStatic(ServletContextThreadLocal.class)) {
+            servletContextThreadLocalMockedStatic.when(ServletContextThreadLocal::getContext).thenReturn(servletContext);
+            assertTrue(HttpUtil.isLongRunningTaskSupported());
+        }
     }
 
     @Test
@@ -221,11 +204,10 @@ public class HttpUtilTest {
         final ServletContext servletContext = mock(ServletContext.class);
         doReturn(serverInfo).when(servletContext).getServerInfo();
 
-        PowerMock.mockStatic(ServletContextThreadLocal.class);
-        expect(ServletContextThreadLocal.getContext()).andReturn(servletContext).anyTimes();
-        PowerMock.replay(ServletContextThreadLocal.class);
-
-        assertTrue(HttpUtil.isLongRunningTaskSupported());
+        try (MockedStatic<ServletContextThreadLocal> servletContextThreadLocalMockedStatic = mockStatic(ServletContextThreadLocal.class)) {
+            servletContextThreadLocalMockedStatic.when(ServletContextThreadLocal::getContext).thenReturn(servletContext);
+            assertTrue(HttpUtil.isLongRunningTaskSupported());
+        }
     }
 
     @Test
@@ -237,11 +219,10 @@ public class HttpUtilTest {
         doReturn("unsupportedone,otherone").when(servletContext)
                 .getInitParameter(SERVLET_CONTEXT_INIT_PARAM_EXPORT_TASK);
 
-        PowerMock.mockStatic(ServletContextThreadLocal.class);
-        expect(ServletContextThreadLocal.getContext()).andReturn(servletContext).anyTimes();
-        PowerMock.replay(ServletContextThreadLocal.class);
-
-        assertFalse(HttpUtil.isLongRunningTaskSupported());
+        try (MockedStatic<ServletContextThreadLocal> servletContextThreadLocalMockedStatic = mockStatic(ServletContextThreadLocal.class)) {
+            servletContextThreadLocalMockedStatic.when(ServletContextThreadLocal::getContext).thenReturn(servletContext);
+            assertTrue(HttpUtil.isLongRunningTaskSupported());
+        }
     }
 
 }


### PR DESCRIPTION
The upgrade to Mockito 5 required to replace a few static imports.

The replacement of PowerMock with Mockito's "new" static mocking capabilities required to change the test runners and some other annotations, as well of course replacing the actual mocking code.